### PR TITLE
Make run_all_tests.sh executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ under its respective `tests` directory. A helper script runs them all:
 ```bash
 ./run_all_tests.sh
 ```
+This script executes unit tests for the API, File Reader, and Downloader
+services and, when `pytest` is available, the embedding service's test suite.
 
 To collect coverage you need the `coverage` package installed. Example for the
 API service:

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
+#
+# Run all test suites across the repository so CI can verify every
+# microservice before merging changes.
 
 set -e
 
-services=(
+# Standard unittest suites
+unittest_services=(
   "api_service/tests"
   "file_reader_service/tests"
   "downloader_service/tests"
 )
 
-for suite in "${services[@]}"; do
+for suite in "${unittest_services[@]}"; do
   echo "Running tests in $suite"
   python3 -m unittest discover "$suite" -v
 done
+
+# Pytest-based suite for the embedding service
+if command -v pytest >/dev/null 2>&1; then
+  echo "Running tests in embedding_service/src/tests"
+  pytest embedding_service/src/tests -v
+else
+  echo "pytest not installed; skipping embedding_service tests" >&2
+fi


### PR DESCRIPTION
## Summary
- fix permissions for `run_all_tests.sh` so it can run in CI
- expand the script to run tests for all microservices

## Testing
- `./run_all_tests.sh`