### PR TITLE
Fix CI workflow to make test script executable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r api_service/requirements.txt -r file_reader_service/requirements.txt -r downloader_service/requirements.txt
+      - name: Make test script executable
+        run: chmod +x run_all_tests.sh
       - name: Run tests
         run: ./run_all_tests.sh


### PR DESCRIPTION
## Summary
- update CI workflow to `chmod +x` the test script before running it

## Testing
- `./run_all_tests.sh`