### PR TITLE
Fix coverage path for file_reader_service

### DIFF
--- a/file_reader_service/tests/pytest.ini
+++ b/file_reader_service/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=downloader_service --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=file_reader_service --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- fix coverage settings for file_reader_service test suite

## Testing
- `bash run_all_tests.sh` *(fails: `pytest` not installed)*
- `bash check-code-quality.sh` *(fails: many files would be reformatted)*