### PR TITLE
Fix coverage paths in pytest configs

### DIFF
--- a/downloader_service/tests/pytest.ini
+++ b/downloader_service/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=downloader_service --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto

--- a/embedding_service/src/tests/pytest.ini
+++ b/embedding_service/src/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=downloader_service --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=.. --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto

--- a/file_reader_service/tests/pytest.ini
+++ b/file_reader_service/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=downloader_service --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- update coverage paths for file reader service tests
- update coverage paths for downloader service tests
- update coverage paths for embedding service tests

## Testing
- `bash run_all_tests.sh` *(fails: pytest not installed)*