### PR TITLE
Fix coverage paths for service tests

### DIFF
--- a/downloader_service/tests/pytest.ini
+++ b/downloader_service/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=downloader_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto

--- a/embedding_service/src/tests/pytest.ini
+++ b/embedding_service/src/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=.. --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=embedding_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto

--- a/file_reader_service/tests/pytest.ini
+++ b/file_reader_service/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=file_reader_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- fix incorrect `--cov` paths that broke coverage for CI

## Testing
- `git status --short`