### PR TITLE
Fix coverage path for file_reader_service

### DIFF
--- a/file_reader_service/tests/pytest.ini
+++ b/file_reader_service/tests/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
+# Reference the service's source directory directly so coverage can locate the
+# modules correctly when the tests are invoked from the repository root.
+addopts = --cov=src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- fix coverage path in `file_reader_service/tests/pytest.ini`

## Testing
- `bash run_all_tests.sh` *(fails: pytest not installed)*