### PR TITLE
Fix coverage path for file_reader_service

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -20,5 +20,5 @@ fi
 
 for suite in "${services[@]}"; do
   echo "Running tests in $suite"
-  pytest "$suite" -v
+  (cd "$suite" && pytest -v)
 done


### PR DESCRIPTION
## Summary
- run each test suite from its directory so relative coverage paths resolve correctly

## Testing
- `bash run_all_tests.sh` *(fails: pytest not installed)*