### PR TITLE
Increase downloader service test coverage

### DIFF
--- a/downloader_service/tests/unit/test_downloader_service.py
+++ b/downloader_service/tests/unit/test_downloader_service.py
@@ -1,0 +1,152 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+root_path = os.path.join(os.path.dirname(__file__), "..", "..", "src")
+sys.path.insert(0, root_path)
+
+# Stub external modules that may not be installed
+sys.modules.setdefault("aio_pika", types.ModuleType("aio_pika"))
+redis_mod = types.ModuleType("redis")
+redis_async_mod = types.ModuleType("redis.asyncio")
+
+
+class DummyRedis:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def pipeline(self):
+        return AsyncMock()
+
+
+redis_async_mod.Redis = DummyRedis
+sys.modules["redis"] = redis_mod
+sys.modules["redis.asyncio"] = redis_async_mod
+aiohttp_mod = types.ModuleType("aiohttp")
+aiohttp_mod.ClientSession = AsyncMock
+
+
+class DummyError(Exception):
+    pass
+
+
+aiohttp_mod.ClientConnectorError = DummyError
+aiohttp_mod.ClientResponseError = DummyError
+aiohttp_mod.ClientError = DummyError
+sys.modules.setdefault("aiohttp", aiohttp_mod)
+pybloom_mod = types.ModuleType("pybloom_live")
+
+
+class DummyBloom:
+    def __init__(self, *a, **k):
+        self.set = set()
+
+    def __contains__(self, item):
+        return item in self.set
+
+    def add(self, item):
+        self.set.add(item)
+
+
+pybloom_mod.BloomFilter = DummyBloom
+sys.modules.setdefault("pybloom_live", pybloom_mod)
+prom_mod = types.ModuleType("prometheus_client")
+prom_mod.Counter = lambda *a, **k: None
+prom_mod.Histogram = lambda *a, **k: None
+prom_mod.start_http_server = lambda *a, **k: None
+sys.modules.setdefault("prometheus_client", prom_mod)
+asyncpg_mod = types.ModuleType("asyncpg")
+asyncpg_mod.create_pool = AsyncMock()
+sys.modules.setdefault("asyncpg", asyncpg_mod)
+
+from domain.download_service import DownloaderService
+
+
+class MockResponse:
+    def __init__(self, status=200, data=b"data"):
+        self.status = status
+        self._data = data
+
+    async def read(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            from aiohttp import ClientResponseError
+
+            raise ClientResponseError(
+                request_info=None, history=(), status=self.status, message="error"
+            )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class TestDownloaderService(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.mock_db = AsyncMock()
+        self.mock_redis = AsyncMock()
+        patcher = patch("domain.download_service.aiohttp.ClientSession")
+        self.addCleanup(patcher.stop)
+        self.mock_session_cls = patcher.start()
+        self.mock_session = self.mock_session_cls.return_value
+        self.service = DownloaderService(database=self.mock_db, redis_client=self.mock_redis)
+        self.service.session = self.mock_session
+
+    async def test_download_image_success(self):
+        self.mock_redis.acquire_download_lock.return_value = True
+        self.mock_redis.is_url_downloaded.return_value = False
+        self.mock_redis.is_url_marked_as_not_found.return_value = False
+        self.mock_db.store_image_record = AsyncMock(return_value=123)
+        self.mock_session.get.return_value = MockResponse(200, b"abc")
+
+        with (
+            patch("domain.download_service.os.makedirs"),
+            patch("builtins.open", mock_open()),
+            patch("domain.download_service.images_downloaded") as mock_counter,
+            patch("domain.download_service.download_latency") as mock_latency,
+        ):
+            result = await self.service.download_image("http://example.com/a.jpg")
+            self.assertEqual(result[0], 123)
+            self.assertTrue(result[1].endswith(".jpg"))
+            mock_counter.inc.assert_called_once()
+            mock_latency.observe.assert_called_once()
+
+    async def test_download_image_invalid_url(self):
+        self.mock_redis.acquire_download_lock.return_value = True
+        with (
+            patch.object(DownloaderService, "is_valid_url", return_value=False),
+            patch("domain.download_service.download_errors") as mock_errors,
+        ):
+            result = await self.service.download_image("bad-url")
+            self.assertIsNone(result)
+            mock_errors.inc.assert_called_once()
+
+    async def test_download_image_404(self):
+        self.mock_redis.acquire_download_lock.return_value = True
+        self.mock_redis.is_url_downloaded.return_value = False
+        self.mock_redis.is_url_marked_as_not_found.return_value = False
+        self.mock_session.get.return_value = MockResponse(404)
+        self.mock_redis.cache_url_as_not_found = AsyncMock()
+        with (
+            patch("domain.download_service.download_errors") as mock_errors,
+            patch("domain.download_service.download_latency"),
+            patch("domain.download_service.images_downloaded"),
+        ):
+            result = await self.service.download_image("http://example.com/missing.jpg")
+            self.assertIsNone(result)
+            mock_errors.inc.assert_not_called()
+
+    def test_generate_filename(self):
+        name = DownloaderService.generate_filename("http://example.com/img.png")
+        self.assertTrue(name.endswith(".png"))
+        self.assertEqual(len(name.split(".")[0]), 64)
+
+    def test_is_valid_url(self):
+        self.assertTrue(DownloaderService.is_valid_url("http://example.com"))
+        self.assertFalse(DownloaderService.is_valid_url("not-a-url"))

--- a/downloader_service/tests/unit/test_misc.py
+++ b/downloader_service/tests/unit/test_misc.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, patch
+
+root_path = os.path.join(os.path.dirname(__file__), "..", "..", "src")
+sys.path.insert(0, root_path)
+
+sys.modules.setdefault("aio_pika", types.ModuleType("aio_pika"))
+sys.modules.setdefault("redis", types.ModuleType("redis"))
+sys.modules.setdefault("redis.asyncio", types.ModuleType("redis.asyncio"))
+asyncpg_mod = types.ModuleType("asyncpg")
+asyncpg_mod.create_pool = AsyncMock()
+sys.modules.setdefault("asyncpg", asyncpg_mod)
+prom_mod = types.ModuleType("prometheus_client")
+prom_mod.Counter = lambda *a, **k: None
+prom_mod.Histogram = lambda *a, **k: None
+prom_mod.start_http_server = lambda *a, **k: None
+sys.modules.setdefault("prometheus_client", prom_mod)
+
+from application.server_runner import run_api_server
+from application.shutdown import shutdown
+from infrastructure.database import Database
+from infrastructure.metrics import start_metrics_server
+from interface.api import health_check
+
+
+class TestMisc(unittest.IsolatedAsyncioTestCase):
+    async def test_run_api_server(self):
+        with patch("application.server_runner.uvicorn.Server") as server_cls:
+            server = AsyncMock()
+            server_cls.return_value = server
+            await run_api_server("0.0.0.0", 1234)
+            server.serve.assert_awaited_once()
+
+    def test_shutdown(self):
+        with patch("asyncio.all_tasks", return_value=[AsyncMock()]) as all_tasks:
+            shutdown()
+            all_tasks.assert_called_once()
+
+    async def test_start_metrics_server(self):
+        with patch("infrastructure.metrics.start_http_server") as start_http:
+            start_metrics_server(port=9999)
+            start_http.assert_called_once_with(9999)
+
+    async def test_api_health_check(self):
+        result = await health_check()
+        self.assertEqual(result["status"], "ok")
+
+
+class TestDatabase(unittest.IsolatedAsyncioTestCase):
+    async def test_store_image_record(self):
+        db = Database()
+        db.pool = AsyncMock()
+        conn = AsyncMock()
+
+        class DummyAcquire:
+            def __init__(self, c):
+                self.c = c
+
+            async def __aenter__(self):
+                return self.c
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        db.pool.acquire = lambda: DummyAcquire(conn)
+
+        conn.fetchrow = AsyncMock(side_effect=[{"id": 5}, None])
+        result = await db.store_image_record("u", "/f")
+        self.assertEqual(result, 5)
+
+        conn.fetchrow = AsyncMock(side_effect=[None, {"id": 7}])
+        result = await db.store_image_record("u2", "/f2")
+        self.assertEqual(result, 7)
+
+        conn.fetchrow = AsyncMock(side_effect=[None, None])
+        result = await db.store_image_record("u3", "/f3")
+        self.assertIsNone(result)

--- a/downloader_service/tests/unit/test_rabbitmq_client.py
+++ b/downloader_service/tests/unit/test_rabbitmq_client.py
@@ -1,0 +1,71 @@
+import json
+import os
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, patch
+
+root_path = os.path.join(os.path.dirname(__file__), "..", "..", "src")
+sys.path.insert(0, root_path)
+
+aio_pika_mod = types.ModuleType("aio_pika")
+
+
+class DummyMsg:
+    def __init__(self, body=b""):
+        self.body = body
+
+
+aio_pika_mod.Message = DummyMsg
+aio_pika_mod.IncomingMessage = DummyMsg
+sys.modules["aio_pika"] = aio_pika_mod
+sys.modules.setdefault("redis", types.ModuleType("redis"))
+sys.modules.setdefault("redis.asyncio", types.ModuleType("redis.asyncio"))
+
+from infrastructure import rabbitmq_client as rabbitmq_client_module
+from infrastructure.rabbitmq_client import RabbitMQClient
+
+rabbitmq_client_module.aio_pika.Message = DummyMsg
+rabbitmq_client_module.aio_pika.IncomingMessage = DummyMsg
+
+
+class FakeMessage:
+    def __init__(self, body):
+        self.body = body
+
+    class _CM:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    def process(self):
+        return self._CM()
+
+
+class TestRabbitMQClient(unittest.IsolatedAsyncioTestCase):
+    async def test_create_on_message(self):
+        client = RabbitMQClient()
+        callback = AsyncMock()
+        on_message = client._create_on_message(callback)
+
+        data = json.dumps({"url": "http://example.com"}).encode()
+        msg = FakeMessage(data)
+        await on_message(msg)
+        callback.assert_awaited_once_with("http://example.com")
+
+    async def test_publish_and_consume(self):
+        client = RabbitMQClient()
+        client.channel = AsyncMock()
+        queue = AsyncMock()
+        client.channel.declare_queue = AsyncMock(return_value=queue)
+        queue.consume = AsyncMock()
+        client.channel.default_exchange.publish = AsyncMock()
+
+        await client.publish("q", "msg")
+        client.channel.declare_queue.assert_called_with("q", durable=True)
+        client.channel.default_exchange.publish.assert_awaited()
+
+        await client.consume("q", AsyncMock())
+        queue.consume.assert_awaited()

--- a/downloader_service/tests/unit/test_redis_client.py
+++ b/downloader_service/tests/unit/test_redis_client.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock
+
+root_path = os.path.join(os.path.dirname(__file__), "..", "..", "src")
+sys.path.insert(0, root_path)
+
+sys.modules.setdefault("aio_pika", types.ModuleType("aio_pika"))
+redis_mod = types.ModuleType("redis")
+redis_async_mod = types.ModuleType("redis.asyncio")
+
+
+class DummyRedis:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def pipeline(self):
+        return AsyncMock()
+
+
+redis_async_mod.Redis = DummyRedis
+sys.modules["redis"] = redis_mod
+sys.modules["redis.asyncio"] = redis_async_mod
+
+from infrastructure.redis_client import RedisClient
+
+
+class FakePipeline:
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def exists(self, key):
+        self.calls.append(key)
+        return self
+
+    async def execute(self):
+        return self.results
+
+
+class TestRedisClient(unittest.IsolatedAsyncioTestCase):
+    async def test_check_urls_batch(self):
+        client = RedisClient()
+        results_iter = iter([[0, 1, 0], [0, 0, 1]])
+
+        def pipeline_side_effect():
+            return FakePipeline(next(results_iter))
+
+        redis_mock = types.SimpleNamespace(pipeline=pipeline_side_effect)
+        client.redis = redis_mock
+
+        urls = ["a", "b", "c"]
+        remaining = await client.check_urls_batch(urls)
+        self.assertEqual(remaining, ["a"])


### PR DESCRIPTION
## Summary
- add a comprehensive set of unit tests for the downloader service
- cover rabbitmq client helpers, redis client batch check and misc modules

## Testing
- `python -m unittest discover downloader_service/tests -v`