### PR TITLE
Fix coverage path for file_reader_service

### DIFF
--- a/file_reader_service/tests/pytest.ini
+++ b/file_reader_service/tests/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
+# Collect coverage relative to the repository root so executing tests from any
+# working directory will target the correct source files.
+addopts = --cov=file_reader_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- fix addopts path so coverage runs properly for file_reader_service

## Testing
- `pytest file_reader_service/tests` *(fails: command not found)*