### PR TITLE
Fix coverage paths in test configs

### DIFF
--- a/downloader_service/tests/pytest.ini
+++ b/downloader_service/tests/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
+# --cov path is relative to the repository root
+addopts = --cov=downloader_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto

--- a/embedding_service/src/tests/pytest.ini
+++ b/embedding_service/src/tests/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=.. --cov-report=term-missing --cov-fail-under=80
+# --cov path is relative to the repository root
+addopts = --cov=embedding_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- adjust pytest coverage paths in downloader and embedding services

## Testing
- `pytest downloader_service/tests` *(fails: command not found)*
- `pytest embedding_service/src/tests` *(fails: command not found)*
- `bash run_all_tests.sh` *(fails: pytest not installed)*
