### PR TITLE
Fix coverage path

### DIFF
--- a/file_reader_service/tests/pytest.ini
+++ b/file_reader_service/tests/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=../src --cov-report=term-missing --cov-fail-under=80
+# --cov path is relative to the repository root
+addopts = --cov=file_reader_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- update pytest.ini coverage settings with clarifying comment

## Testing
- `bash ./check-code-quality.sh` *(fails: many files would be reformatted)*
- `bash ./run_all_tests.sh` *(fails: pytest not installed)*