### PR TITLE
Add pytest config for API service

### DIFF
--- a/api_service/tests/pytest.ini
+++ b/api_service/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+minversion = 6.0
+addopts = --cov=api_service/src --cov-report=term-missing --cov-fail-under=80
+testpaths = unit integration e2e
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- add pytest.ini for `api_service` test suite

## Testing
- `bash ./check-code-quality.sh` *(fails: many files need formatting)*
- `bash ./run_all_tests.sh` *(fails: pytest not installed)*