### PR TITLE
Add unit tests for API service

### DIFF
--- a/api_service/tests/unit/test_api.py
+++ b/api_service/tests/unit/test_api.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import types
+import importlib
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+# Stub httpx before importing TestClient to avoid missing dependency
+sys.modules.setdefault('httpx', types.ModuleType('httpx'))
+
+root_path = os.path.join(os.path.dirname(__file__), '..', '..', 'src')
+sys.path.insert(0, os.path.abspath(root_path))
+
+
+class Counter:
+    def __init__(self):
+        self.calls = 0
+    def inc(self):
+        self.calls += 1
+
+class Histogram:
+    def __init__(self):
+        self.values = []
+    def observe(self, value):
+        self.values.append(value)
+
+
+class TestAPI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        embed_service = MagicMock()
+        embed_service.generate_embedding_from_text = MagicMock(return_value=[0.1, 0.2])
+        embed_module = types.ModuleType('domain.embedding_service')
+        embed_module.EmbeddingService = lambda: embed_service
+        sys.modules['domain.embedding_service'] = embed_module
+
+        es_client = types.SimpleNamespace(
+            search_embeddings=AsyncMock(return_value=[{'image_id': 1, 'image_url': 'u', 'image_path': 'p', 'score': 0.9}]),
+            close=AsyncMock()
+        )
+        es_module = types.ModuleType('infrastructure.elasticsearch_client')
+        es_module.elasticsearch_client = es_client
+        sys.modules['infrastructure.elasticsearch_client'] = es_module
+
+        metrics_module = types.ModuleType('infrastructure.metrics')
+        metrics_module.queries_total = Counter()
+        metrics_module.query_errors_total = Counter()
+        metrics_module.query_latency = Histogram()
+        sys.modules['infrastructure.metrics'] = metrics_module
+
+        prom_module = types.ModuleType('prometheus_client')
+        prom_module.generate_latest = lambda: b'metrics'
+        prom_module.CONTENT_TYPE_LATEST = 'text/plain'
+        sys.modules['prometheus_client'] = prom_module
+
+        # Stub httpx required by FastAPI TestClient
+        httpx_module = types.ModuleType('httpx')
+        sys.modules.setdefault('httpx', httpx_module)
+
+        import interface.api as api_module
+        importlib.reload(api_module)
+        cls.api = api_module
+        cls.metrics = metrics_module
+        cls.embed_service = api_module.embedding_service
+
+    def test_health_endpoint(self):
+        response = asyncio.run(self.api.health())
+        self.assertEqual(response, {'status': 'ok', 'service': 'api_server'})
+
+    def test_get_image_success(self):
+        self.embed_service.generate_embedding_from_text.return_value = [0.1, 0.2]
+        before = self.metrics.queries_total.calls
+        err_before = self.metrics.query_errors_total.calls
+        data = asyncio.run(self.api.get_image(query_string='hi', page=1, size=1))
+        self.assertEqual(data.query, 'hi')
+        self.assertEqual(len(data.results), 1)
+        self.assertEqual(data.results[0].image_id, 1)
+        self.assertEqual(self.metrics.queries_total.calls, before + 1)
+        self.assertEqual(self.metrics.query_errors_total.calls, err_before)
+
+    def test_get_image_embedding_failure(self):
+        self.embed_service.generate_embedding_from_text.return_value = []
+        before = self.metrics.query_errors_total.calls
+        with self.assertRaises(self.api.HTTPException):
+            asyncio.run(self.api.get_image(query_string='bad', page=1, size=1))
+        self.assertEqual(self.metrics.query_errors_total.calls, before + 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/api_service/tests/unit/test_embedding_service.py
+++ b/api_service/tests/unit/test_embedding_service.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import types
+import contextlib
+import importlib
+import unittest
+from unittest.mock import MagicMock
+
+root_path = os.path.join(os.path.dirname(__file__), '..', '..', 'src')
+sys.path.insert(0, os.path.abspath(root_path))
+
+
+class FakeTensor:
+    def __init__(self, arr):
+        self.arr = list(arr)
+        self.shape = (1, len(self.arr))
+
+    def to(self, device):
+        return self
+
+    def norm(self, dim=-1, keepdim=True):
+        import math
+        return FakeTensor([math.sqrt(sum(x * x for x in self.arr))])
+
+    def __truediv__(self, other):
+        val = other.arr[0] if isinstance(other, FakeTensor) else other
+        return FakeTensor([x / val for x in self.arr])
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self
+
+    def tolist(self):
+        return [self.arr]
+
+
+def setup_modules(mock_model):
+    clip_module = types.ModuleType('clip')
+    clip_module.load = lambda model_name, device=None: (mock_model, None)
+    clip_module.tokenize = lambda text: FakeTensor([0])
+    sys.modules['clip'] = clip_module
+
+    torch_module = types.ModuleType('torch')
+    torch_module.cuda = types.SimpleNamespace(is_available=lambda: False)
+    torch_module.no_grad = contextlib.nullcontext
+    sys.modules['torch'] = torch_module
+
+
+class TestEmbeddingService(unittest.TestCase):
+    def tearDown(self):
+        sys.modules.pop('clip', None)
+        sys.modules.pop('torch', None)
+        sys.modules.pop('domain.embedding_service', None)
+
+    def test_generate_embedding_success(self):
+        mock_model = MagicMock()
+        mock_model.encode_text.return_value = FakeTensor([1.0, 0.0])
+        setup_modules(mock_model)
+        import domain.embedding_service as emb_mod
+        importlib.reload(emb_mod)
+        service = emb_mod.EmbeddingService()
+        embedding = service.generate_embedding_from_text('hi')
+        self.assertEqual(embedding, [1.0, 0.0])
+
+    def test_generate_embedding_failure(self):
+        mock_model = MagicMock()
+        mock_model.encode_text.return_value = FakeTensor([1.0])
+        setup_modules(mock_model)
+        import domain.embedding_service as emb_mod
+        importlib.reload(emb_mod)
+        service = emb_mod.EmbeddingService()
+        service.model.encode_text.side_effect = Exception('fail')
+        embedding = service.generate_embedding_from_text('hi')
+        self.assertEqual(embedding, [])
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/api_service/tests/unit/test_main.py
+++ b/api_service/tests/unit/test_main.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+root_path = os.path.join(os.path.dirname(__file__), '..', '..', 'src')
+sys.path.insert(0, os.path.abspath(root_path))
+
+
+class TestMain(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        es_module = types.ModuleType('infrastructure.elasticsearch_client')
+        es_module.elasticsearch_client = types.SimpleNamespace(
+            es=types.SimpleNamespace(ping=AsyncMock()),
+            close=AsyncMock()
+        )
+        sys.modules['infrastructure.elasticsearch_client'] = es_module
+
+        metrics_module = types.ModuleType('infrastructure.metrics')
+        metrics_module.start_metrics_server = MagicMock()
+        sys.modules['infrastructure.metrics'] = metrics_module
+
+        config_module = types.ModuleType('infrastructure.config')
+        config_module.settings = types.SimpleNamespace(METRICS_PORT=9876)
+        sys.modules['infrastructure.config'] = config_module
+
+        logger_module = types.ModuleType('infrastructure.logging_config')
+        logger_module.logger = MagicMock()
+        sys.modules['infrastructure.logging_config'] = logger_module
+
+        import main as main_module
+        importlib.reload(main_module)
+        self.main = main_module
+        self.es = es_module.elasticsearch_client
+        self.metrics = metrics_module
+
+    async def test_startup_and_shutdown(self):
+        await self.main.startup_event()
+        self.es.es.ping.assert_awaited_once()
+        self.metrics.start_metrics_server.assert_called_once_with(port=9876)
+
+        await self.main.shutdown_event()
+        self.es.close.assert_awaited_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/api_service/tests/unit/test_metrics.py
+++ b/api_service/tests/unit/test_metrics.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import types
+import importlib
+import unittest
+from unittest.mock import MagicMock
+
+root_path = os.path.join(os.path.dirname(__file__), '..', '..', 'src')
+sys.path.insert(0, os.path.abspath(root_path))
+
+
+class TestMetrics(unittest.TestCase):
+    def tearDown(self):
+        sys.modules.pop('prometheus_client', None)
+        sys.modules.pop('infrastructure.metrics', None)
+
+    def test_start_metrics_server_success(self):
+        prom_module = types.ModuleType('prometheus_client')
+        prom_module.start_http_server = MagicMock()
+        prom_module.Counter = MagicMock
+        prom_module.Histogram = MagicMock
+        sys.modules['prometheus_client'] = prom_module
+
+        import infrastructure.metrics as metrics
+        importlib.reload(metrics)
+        metrics.start_metrics_server(port=1234)
+        prom_module.start_http_server.assert_called_once_with(1234)
+
+    def test_start_metrics_server_failure(self):
+        prom_module = types.ModuleType('prometheus_client')
+        prom_module.start_http_server = MagicMock(side_effect=Exception('boom'))
+        prom_module.Counter = MagicMock
+        prom_module.Histogram = MagicMock
+        sys.modules['prometheus_client'] = prom_module
+
+        import infrastructure.metrics as metrics
+        importlib.reload(metrics)
+        with self.assertRaises(Exception):
+            metrics.start_metrics_server(port=1234)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- increase API service test coverage with new unit tests

## Testing
- `bash check-code-quality.sh` *(fails: many files would reformat)*
- `bash run_all_tests.sh` *(fails: ModuleNotFoundError in file_reader_service tests)*