### PR TITLE
Fix service coverage paths

### DIFF
--- a/downloader_service/tests/pytest.ini
+++ b/downloader_service/tests/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 minversion = 6.0
+# --cov path is relative to the repository root
 addopts = --cov=downloader_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto

--- a/embedding_service/src/tests/pytest.ini
+++ b/embedding_service/src/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 6.0
-addopts = --cov=.. --cov-report=term-missing --cov-fail-under=80
+addopts = --cov=embedding_service/src --cov-report=term-missing --cov-fail-under=80
 testpaths = unit integration e2e
 asyncio_mode = auto


### PR DESCRIPTION
## Summary
- fix downloader test config comment
- fix embedding service test coverage path

## Testing
- `bash ./check-code-quality.sh` *(fails: found 51 errors)*
- `bash ./run_all_tests.sh` *(fails: pytest not installed)*