### PR TITLE
Fix prometheus test stubs

### DIFF
--- a/embedding_service/src/tests/e2e/test_full_flow.py
+++ b/embedding_service/src/tests/e2e/test_full_flow.py
@@ -1,9 +1,10 @@
-import unittest
+import contextlib
 import os
 import sys
 import types
-import contextlib
-from unittest.mock import AsyncMock, patch, MagicMock
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 root_path = os.path.join(os.path.dirname(__file__), "..", "..")
 sys.path.insert(0, root_path)
@@ -16,13 +17,20 @@ torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False)
 torch_stub.no_grad = contextlib.nullcontext
 sys.modules.setdefault("torch", torch_stub)
 clip_stub = types.ModuleType("clip")
-clip_stub.load = lambda model_name, device=None: (MagicMock(encode_image=MagicMock(return_value=MagicMock(shape=(1,1)))), lambda x: x)
+clip_stub.load = lambda model_name, device=None: (
+    MagicMock(encode_image=MagicMock(return_value=MagicMock(shape=(1, 1)))),
+    lambda x: x,
+)
 sys.modules.setdefault("clip", clip_stub)
+
+
 def dummy_image():
     class Dummy:
         def convert(self, mode):
             return self
+
     return Dummy()
+
 
 pil_module = types.ModuleType("PIL")
 pil_image_module = types.ModuleType("PIL.Image")
@@ -30,21 +38,48 @@ pil_image_module.new = lambda *args, **kwargs: dummy_image()
 pil_module.Image = pil_image_module
 sys.modules.setdefault("PIL", pil_module)
 sys.modules.setdefault("PIL.Image", pil_image_module)
-prometheus_stub = types.ModuleType("prometheus_client")
-prometheus_stub.Counter = MagicMock
-prometheus_stub.Histogram = MagicMock
-prometheus_stub.start_http_server = MagicMock
-sys.modules.setdefault("prometheus_client", prometheus_stub)
 
-from domain.embedding_service import EmbeddingService
+
+class Counter:
+    def __init__(self, *_, **__):
+        self._val = 0.0
+        self._value = SimpleNamespace(get=lambda: self._val)
+
+    def inc(self, amount: float = 1.0) -> None:
+        self._val += amount
+
+
+class Histogram:
+    def __init__(self, *_, **__):
+        self._val = 0.0
+        self._value = SimpleNamespace(get=lambda: self._val)
+
+    def observe(self, value: float) -> None:  # noqa: ARG002
+        self._val += 1
+
+
+prometheus_stub = types.ModuleType("prometheus_client")
+prometheus_stub.Counter = Counter
+prometheus_stub.Histogram = Histogram
+prometheus_stub.start_http_server = MagicMock()
+sys.modules["prometheus_client"] = prometheus_stub
+
 from application.message_processor import process_message
+from domain.embedding_service import EmbeddingService
+
 
 class TestEmbeddingE2E(unittest.IsolatedAsyncioTestCase):
     async def test_full_flow(self):
-        with patch("domain.embedding_service.EmbeddingService.__init__", lambda self, model_name="ViT-B/32": None):
+        with patch(
+            "domain.embedding_service.EmbeddingService.__init__",
+            lambda self, model_name="ViT-B/32": None,
+        ):
             service = EmbeddingService(model_name="ViT-B/32")
-        with patch.object(service, "generate_embedding_from_image", return_value=[0.1]) as mock_gen, \
-             patch("application.message_processor.elasticsearch_client") as mock_es:
+        with patch.object(
+            service, "generate_embedding_from_image", return_value=[0.1]
+        ) as mock_gen, patch(
+            "application.message_processor.elasticsearch_client"
+        ) as mock_es:
             mock_es.index_embedding = AsyncMock(return_value=None)
             data = {"image_id": 1, "image_url": "u", "image_path": "p"}
             await process_message(data, service)

--- a/embedding_service/src/tests/integration/test_message_processor.py
+++ b/embedding_service/src/tests/integration/test_message_processor.py
@@ -1,10 +1,10 @@
-import unittest
+import contextlib
 import os
 import sys
 import types
-import contextlib
-from unittest.mock import MagicMock
-from unittest.mock import patch, AsyncMock
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 root_path = os.path.join(os.path.dirname(__file__), "..", "..")
 sys.path.insert(0, root_path)
@@ -18,13 +18,20 @@ torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False)
 torch_stub.no_grad = contextlib.nullcontext
 sys.modules.setdefault("torch", torch_stub)
 clip_stub = types.ModuleType("clip")
-clip_stub.load = lambda model_name, device=None: (MagicMock(encode_image=MagicMock(return_value=MagicMock(shape=(1,1)))), lambda x: x)
+clip_stub.load = lambda model_name, device=None: (
+    MagicMock(encode_image=MagicMock(return_value=MagicMock(shape=(1, 1)))),
+    lambda x: x,
+)
 sys.modules.setdefault("clip", clip_stub)
+
+
 def dummy_image():
     class Dummy:
         def convert(self, mode):
             return self
+
     return Dummy()
+
 
 pil_module = types.ModuleType("PIL")
 pil_image_module = types.ModuleType("PIL.Image")
@@ -32,21 +39,48 @@ pil_image_module.new = lambda *args, **kwargs: dummy_image()
 pil_module.Image = pil_image_module
 sys.modules.setdefault("PIL", pil_module)
 sys.modules.setdefault("PIL.Image", pil_image_module)
-prometheus_stub = types.ModuleType("prometheus_client")
-prometheus_stub.Counter = MagicMock
-prometheus_stub.Histogram = MagicMock
-prometheus_stub.start_http_server = MagicMock
-sys.modules.setdefault("prometheus_client", prometheus_stub)
 
-from domain.embedding_service import EmbeddingService
+
+class Counter:
+    def __init__(self, *_, **__):
+        self._val = 0.0
+        self._value = SimpleNamespace(get=lambda: self._val)
+
+    def inc(self, amount: float = 1.0) -> None:
+        self._val += amount
+
+
+class Histogram:
+    def __init__(self, *_, **__):
+        self._val = 0.0
+        self._value = SimpleNamespace(get=lambda: self._val)
+
+    def observe(self, value: float) -> None:  # noqa: ARG002
+        self._val += 1
+
+
+prometheus_stub = types.ModuleType("prometheus_client")
+prometheus_stub.Counter = Counter
+prometheus_stub.Histogram = Histogram
+prometheus_stub.start_http_server = MagicMock()
+sys.modules["prometheus_client"] = prometheus_stub
+
 from application.message_processor import process_message
+from domain.embedding_service import EmbeddingService
+
 
 class TestMessageProcessorIntegration(unittest.IsolatedAsyncioTestCase):
     async def test_process_message(self):
-        with patch("domain.embedding_service.EmbeddingService.__init__", lambda self, model_name="ViT-B/32": None):
+        with patch(
+            "domain.embedding_service.EmbeddingService.__init__",
+            lambda self, model_name="ViT-B/32": None,
+        ):
             service = EmbeddingService(model_name="ViT-B/32")
-        with patch.object(service, "generate_embedding_from_image", return_value=[0.1]) as mock_gen, \
-             patch("application.message_processor.elasticsearch_client") as mock_es:
+        with patch.object(
+            service, "generate_embedding_from_image", return_value=[0.1]
+        ) as mock_gen, patch(
+            "application.message_processor.elasticsearch_client"
+        ) as mock_es:
             mock_es.index_embedding = AsyncMock(return_value=None)
             data = {"image_id": 1, "image_url": "u", "image_path": "p"}
             await process_message(data, service)

--- a/embedding_service/src/tests/unit/test_embedding_service.py
+++ b/embedding_service/src/tests/unit/test_embedding_service.py
@@ -1,9 +1,10 @@
-import unittest
+import contextlib
 import os
 import sys
 import types
-import contextlib
-from unittest.mock import patch, MagicMock
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 root_path = os.path.join(os.path.dirname(__file__), "..", "..")
 sys.path.insert(0, root_path)
@@ -13,13 +14,20 @@ torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False)
 torch_stub.no_grad = contextlib.nullcontext
 sys.modules.setdefault("torch", torch_stub)
 clip_stub = types.ModuleType("clip")
-clip_stub.load = lambda model_name, device=None: (MagicMock(encode_image=MagicMock(return_value=MagicMock(shape=(1, 1)))), lambda x: x)
+clip_stub.load = lambda model_name, device=None: (
+    MagicMock(encode_image=MagicMock(return_value=MagicMock(shape=(1, 1)))),
+    lambda x: x,
+)
 sys.modules.setdefault("clip", clip_stub)
+
+
 def dummy_image():
     class Dummy:
         def convert(self, mode):
             return self
+
     return Dummy()
+
 
 Image = type("Image", (), {"new": lambda *args, **kwargs: dummy_image()})
 pil_module = types.ModuleType("PIL")
@@ -28,18 +36,44 @@ pil_image_module.new = lambda *args, **kwargs: dummy_image()
 pil_module.Image = pil_image_module
 sys.modules.setdefault("PIL", pil_module)
 sys.modules.setdefault("PIL.Image", pil_image_module)
+
+
+class Counter:
+    def __init__(self, *_, **__):
+        self._val = 0.0
+        self._value = SimpleNamespace(get=lambda: self._val)
+
+    def inc(self, amount: float = 1.0) -> None:
+        self._val += amount
+
+
+class Histogram:
+    def __init__(self, *_, **__):
+        self._val = 0.0
+        self._value = SimpleNamespace(get=lambda: self._val)
+
+    def observe(self, value: float) -> None:  # noqa: ARG002
+        self._val += 1
+
+
 prometheus_stub = types.ModuleType("prometheus_client")
-prometheus_stub.Counter = MagicMock
-prometheus_stub.Histogram = MagicMock
-prometheus_stub.start_http_server = MagicMock
-sys.modules.setdefault("prometheus_client", prometheus_stub)
+prometheus_stub.Counter = Counter
+prometheus_stub.Histogram = Histogram
+prometheus_stub.start_http_server = MagicMock()
+sys.modules["prometheus_client"] = prometheus_stub
 
 from domain.embedding_service import EmbeddingService
 
+
 class TestEmbeddingService(unittest.IsolatedAsyncioTestCase):
     async def test_generate_embedding_from_image(self):
-        with patch("domain.embedding_service.EmbeddingService.__init__", lambda self, model_name="ViT-B/32": None):
+        with patch(
+            "domain.embedding_service.EmbeddingService.__init__",
+            lambda self, model_name="ViT-B/32": None,
+        ):
             service = EmbeddingService(model_name="ViT-B/32")
-        with patch.object(service, "generate_embedding_from_image", return_value=[0.1, 0.2, 0.3]):
+        with patch.object(
+            service, "generate_embedding_from_image", return_value=[0.1, 0.2, 0.3]
+        ):
             embedding = service.generate_embedding_from_image("path/to/image.jpg")
             self.assertEqual(embedding, [0.1, 0.2, 0.3])

--- a/file_reader_service/tests/utils.py
+++ b/file_reader_service/tests/utils.py
@@ -1,6 +1,31 @@
 import sys
 import types
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
+
+
+class _Value:
+    def __init__(self) -> None:
+        self.val = 0.0
+
+    def get(self) -> float:
+        return self.val
+
+
+class Counter:
+    def __init__(self, *_, **__):
+        self._value = _Value()
+
+    def inc(self, amount: float = 1.0) -> None:
+        self._value.val += amount
+
+
+class Histogram:
+    def __init__(self, *_, **__):
+        self._value = _Value()
+
+    def observe(self, value: float) -> None:  # noqa: ARG002
+        self._value.val += 1
 
 
 def setup_stub_modules():
@@ -16,15 +41,19 @@ def setup_stub_modules():
             self.body = body
 
     aio_pika_stub.Message = Message
+
     async def _connect_robust(*args, **kwargs):
-        return types.SimpleNamespace(channel=lambda: AsyncMock())
+        return SimpleNamespace(channel=lambda: AsyncMock())
+
     aio_pika_stub.connect_robust = _connect_robust
     sys.modules["aio_pika"] = aio_pika_stub
 
     redis_mod = types.ModuleType("redis.asyncio")
+
     class DummyRedis:
         def __init__(self, *args, **kwargs):
             pass
+
     redis_mod.Redis = DummyRedis
     sys.modules["redis.asyncio"] = redis_mod
     sys.modules["redis"] = types.ModuleType("redis")
@@ -45,13 +74,17 @@ def setup_stub_modules():
     sys.modules["pybloom_live"] = pybloom_stub
 
     prom_stub = types.ModuleType("prometheus_client")
+    prom_stub.Counter = Counter
+    prom_stub.Histogram = Histogram
     prom_stub.start_http_server = lambda *args, **kwargs: None
     sys.modules["prometheus_client"] = prom_stub
 
     uvicorn_stub = types.ModuleType("uvicorn")
     uvicorn_stub.Config = lambda *a, **k: None
+
     class Server:
         async def serve(self):
             return None
+
     uvicorn_stub.Server = lambda *a, **k: Server()
     sys.modules["uvicorn"] = uvicorn_stub


### PR DESCRIPTION
## Summary
- add simple Counter/Histogram stubs in `file_reader_service` test utils
- override prometheus client stubs in embedding service tests

## Testing
- `bash ./check-code-quality.sh` *(fails: imports incorrectly sorted)*
- `bash ./run_all_tests.sh` *(fails: pytest not installed)*